### PR TITLE
[PKG-6012] 2.8.1 ❄️

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,12 +17,14 @@ build:
 requirements:
   host:
     - pip
-    - python >=3.7,<4.0
+    - python
+    - setuptools
+    - wheel
   run:
     - defusedxml
     - fonttools >=4.34.0
-    - pillow >=6.2.2
-    - python >=3.7,<4.0
+    - pillow >=6.2.2,!=9.2
+    - python
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -61,6 +61,7 @@ about:
     in Python. It is a fork and the successor of PyFPDF.
   license: LGPL-3.0-or-later
   license_file: LICENSE
+  license_family: LGPL
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,12 +27,29 @@ requirements:
     - python
 
 test:
+  source_files:
+    - test
+    # Used in image tests
+    - docs/fpdf2-logo.png
+
   imports:
     - fpdf
   commands:
     - pip check
+    {% set pytest_skip = "test_encryption_unicode" %} # Requires uharfbuzz
+    {% set pytest_skip = pytest_skip + " or test_sign_pkcs12" %} # Requires endesive
+    {% set pytest_skip = pytest_skip + " or test_insert_jpg_jpxdecode" %}
+    {% set pytest_skip = pytest_skip + " or test_insert_jpg_flatedecode" %}
+    {% set pytest_skip = pytest_skip + " or test_insert_png_alpha_dctdecode" %}
+    {% set pytest_skip = pytest_skip + " or test_page_background" %}
+
+    - pytest test --ignore=test/table/test_table_extraction.py --ignore=test/text_shaping -k "not ({{ pytest_skip }})"
   requires:
     - pip
+    - pytest
+    - qrcode
+    - cryptography
+    - lxml
 
 about:
   home: https://pyfpdf.github.io/fpdf2/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,7 +54,11 @@ test:
 about:
   home: https://pyfpdf.github.io/fpdf2/
   dev_url: https://github.com/PyFPDF/fpdf2
+  doc_url: https://py-pdf.github.io/fpdf2/
   summary: Simple PDF generation for Python
+  description: |
+    fpdf2 is a library for simple & fast PDF document generation 
+    in Python. It is a fork and the successor of PyFPDF.
   license: LGPL-3.0-or-later
   license_file: LICENSE
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,8 @@ source:
   
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  skip: true  # [py<37]
+  script: {{ PYTHON }} -m pip install . -vv --no-build-isolation --no-deps
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,14 +1,14 @@
 {% set name = "fpdf2" %}
-{% set version = "2.6.1" %}
+{% set version = "2.8.1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/fpdf2-{{ version }}.tar.gz
-  sha256: c5196b1a5ef5ecb8769d3407db460c08842eb9f96ee9e2558a7d787239dd65b3
-
+  url: https://github.com/py-pdf/fpdf2/archive/refs/tags/{{ version }}.tar.gz
+  sha256: 21e5671fe036b8be2a83519572bc5d3a43f418cb7923bfd64eaba080f8a7c6c6
+  
 build:
   number: 0
   noarch: python


### PR DESCRIPTION
fpdf2 2.8.1 ❄️ 

**Destination channel:** Snowflake

### Links

- [PKG-6012]
- [Upstream repository](https://github.com/PyFPDF/fpdf2)

### Explanation of changes:

- Added upstream tests
  - Swapped to Github source for tests.
  - `text_shaping` tests require `uharfbuzz`
  - `test_table_extraction.py` requires `camelot`


[PKG-6012]: https://anaconda.atlassian.net/browse/PKG-6012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ